### PR TITLE
New ways to click reconnect button.

### DIFF
--- a/src/inject/inject.js
+++ b/src/inject/inject.js
@@ -15,7 +15,11 @@ chrome.extension.sendMessage({}, function (response) {
 
 function clickConnect() {
 	try {
-		document.querySelector("colab-connect-button").click()
+		// This one doesn't work, see https://stackoverflow.com/questions/57113226/how-to-prevent-google-colab-from-disconnecting
+		//document.querySelector("colab-connect-button").click()
+		document.querySelector("#top-toolbar > colab-connect-button").shadowRoot.querySelector("#connect").click()
+		// This one also works.
+		//document.querySelector("colab-connect-button").shadowRoot.getElementById('connect').click()
 		console.log("Keeping Colab Alive!");	
 		
 		


### PR DESCRIPTION
document.querySelector("colab-connect-button").click() method doesn't work see, https://stackoverflow.com/questions/57113226/how-to-prevent-google-colab-from-disconnecting